### PR TITLE
Fix link to your Github profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,7 +91,7 @@ author:
   flickr           :
   facebook         :
   foursquare       :
-  github           : "ptisunov"
+  github           : "tisunov"
   gitlab           :
   google_plus      :
   keybase          :


### PR DESCRIPTION
Footer in your page http://tisunov.github.io/ doesn't links correctly.